### PR TITLE
Create personal profile webpage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,410 @@
+<!DOCTYPE html>
+<html lang="zh-Hans">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Cheng YH · 个人主页</title>
+  <meta name="description" content="Cheng YH 的个人主页，展示简历、项目和联系方式。" />
+  <style>
+    :root {
+      color-scheme: light dark;
+      --primary: #2b59c3;
+      --primary-dark: #1a3e87;
+      --accent: #f4b400;
+      --bg: #f8fafc;
+      --bg-dark: #0f172a;
+      --text: #0f172a;
+      --text-muted: #4b5563;
+      --card-bg: rgba(255, 255, 255, 0.82);
+      --shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0f172a;
+        --bg-dark: #020617;
+        --text: #e2e8f0;
+        --text-muted: #94a3b8;
+        --card-bg: rgba(15, 23, 42, 0.72);
+        --shadow: 0 18px 38px rgba(2, 6, 23, 0.35);
+      }
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html,
+    body {
+      margin: 0;
+      font-family: "SF Pro Display", "Helvetica Neue", "Segoe UI", "PingFang SC", sans-serif;
+      background: linear-gradient(160deg, var(--bg), var(--bg-dark));
+      color: var(--text);
+      min-height: 100%;
+      scroll-behavior: smooth;
+    }
+
+    a {
+      color: inherit;
+      text-decoration: none;
+    }
+
+    header {
+      position: sticky;
+      top: 0;
+      backdrop-filter: blur(12px);
+      background-color: rgba(248, 250, 252, 0.85);
+      border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+      z-index: 100;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      header {
+        background-color: rgba(15, 23, 42, 0.8);
+        border-color: rgba(71, 85, 105, 0.4);
+      }
+    }
+
+    nav {
+      max-width: 960px;
+      margin: 0 auto;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 16px 24px;
+    }
+
+    nav ul {
+      list-style: none;
+      display: flex;
+      gap: 20px;
+      padding: 0;
+      margin: 0;
+      font-size: 0.95rem;
+    }
+
+    nav a:hover,
+    nav a:focus {
+      color: var(--primary);
+    }
+
+    .logo {
+      font-weight: 600;
+      letter-spacing: 0.04em;
+    }
+
+    main {
+      max-width: 960px;
+      margin: 0 auto;
+      padding: 32px 24px 96px;
+    }
+
+    section {
+      margin: 72px 0;
+    }
+
+    .hero {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 32px;
+      align-items: center;
+      padding-top: 64px;
+    }
+
+    .hero-card {
+      background-color: var(--card-bg);
+      border-radius: 22px;
+      padding: 40px;
+      box-shadow: var(--shadow);
+    }
+
+    .hero h1 {
+      font-size: clamp(2.4rem, 5vw, 3.6rem);
+      margin: 0 0 16px;
+    }
+
+    .hero p {
+      margin: 0 0 24px;
+      font-size: 1.05rem;
+      color: var(--text-muted);
+      line-height: 1.6;
+    }
+
+    .cta-group {
+      display: flex;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 12px 20px;
+      border-radius: 999px;
+      font-weight: 600;
+      letter-spacing: 0.01em;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .btn-primary {
+      background: linear-gradient(135deg, var(--primary), var(--primary-dark));
+      color: #fff;
+      box-shadow: 0 16px 30px rgba(43, 89, 195, 0.3);
+    }
+
+    .btn-primary:hover,
+    .btn-primary:focus {
+      transform: translateY(-2px);
+      box-shadow: 0 22px 40px rgba(43, 89, 195, 0.35);
+    }
+
+    .btn-secondary {
+      border: 2px solid rgba(43, 89, 195, 0.4);
+      color: var(--primary);
+      background-color: transparent;
+    }
+
+    .btn-secondary:hover,
+    .btn-secondary:focus {
+      transform: translateY(-2px);
+      border-color: var(--primary);
+    }
+
+    .info-card {
+      background-color: var(--card-bg);
+      border-radius: 18px;
+      padding: 28px;
+      box-shadow: var(--shadow);
+      display: grid;
+      gap: 16px;
+    }
+
+    .info-card h2 {
+      margin: 0;
+      font-size: 1.4rem;
+    }
+
+    .info-card p,
+    .info-card li {
+      margin: 0;
+      color: var(--text-muted);
+      line-height: 1.6;
+    }
+
+    .section-title {
+      font-size: 1.6rem;
+      margin-bottom: 16px;
+    }
+
+    .timeline {
+      display: grid;
+      gap: 16px;
+    }
+
+    .timeline-item {
+      background-color: var(--card-bg);
+      border-radius: 14px;
+      padding: 24px;
+      box-shadow: var(--shadow);
+      position: relative;
+    }
+
+    .timeline-item::before {
+      content: attr(data-year);
+      position: absolute;
+      top: 20px;
+      right: 24px;
+      font-weight: 600;
+      color: var(--primary);
+    }
+
+    .timeline-item h3 {
+      margin: 0 0 8px;
+      font-size: 1.2rem;
+    }
+
+    .chips {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin-top: 12px;
+    }
+
+    .chip {
+      padding: 6px 14px;
+      border-radius: 999px;
+      background-color: rgba(43, 89, 195, 0.15);
+      color: var(--primary-dark);
+      font-size: 0.85rem;
+    }
+
+    footer {
+      text-align: center;
+      padding: 48px 0;
+      color: var(--text-muted);
+      font-size: 0.9rem;
+    }
+
+    @media (max-width: 600px) {
+      nav {
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      nav ul {
+        flex-wrap: wrap;
+        justify-content: center;
+      }
+
+      .hero-card {
+        padding: 28px;
+      }
+
+      .info-card {
+        padding: 22px;
+      }
+
+      .timeline-item {
+        padding: 20px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <nav aria-label="主导航">
+      <a class="logo" href="#top">Cheng YH</a>
+      <ul>
+        <li><a href="#about">关于我</a></li>
+        <li><a href="#experience">经历</a></li>
+        <li><a href="#projects">项目</a></li>
+        <li><a href="#contact">联系</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="top">
+    <section class="hero" aria-labelledby="hero-title">
+      <div class="hero-card">
+        <h1 id="hero-title">你好，我是 Cheng YH</h1>
+        <p>
+          一名热爱设计与开发的全栈创作者，专注于打造简洁优雅、易于使用的数字体验。
+          我相信技术与美学可以相辅相成，让每一个想法都被认真对待。
+        </p>
+        <div class="cta-group">
+          <a class="btn btn-primary" href="#projects">查看项目</a>
+          <a class="btn btn-secondary" href="#contact">联系我</a>
+        </div>
+      </div>
+      <div class="info-card" aria-labelledby="quick-info">
+        <h2 id="quick-info">即时档案</h2>
+        <p><strong>定位：</strong>广州 · 远程</p>
+        <p><strong>角色：</strong>产品策划 / 全栈工程师 / UX 设计师</p>
+        <p><strong>正在做：</strong>探索 AI 赋能个人效率的创意工具</p>
+        <div>
+          <p><strong>技能雷达：</strong></p>
+          <div class="chips">
+            <span class="chip">TypeScript</span>
+            <span class="chip">Vue &amp; React</span>
+            <span class="chip">Node.js</span>
+            <span class="chip">产品设计</span>
+            <span class="chip">品牌视觉</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="about" aria-labelledby="about-title">
+      <h2 class="section-title" id="about-title">关于我</h2>
+      <p>
+        我喜欢在技术与美学的交汇处解决问题。过去几年，我在互联网产品团队中先后担任
+        设计师与工程师角色，擅长从用户需求出发，快速将想法落地为可持续迭代的产品。无论是
+        从零到一的探索，还是成熟产品的体验优化，我都乐于深入理解场景并给出高质量的解决方案。
+      </p>
+    </section>
+
+    <section id="experience" aria-labelledby="experience-title">
+      <h2 class="section-title" id="experience-title">经历</h2>
+      <div class="timeline" role="list">
+        <article class="timeline-item" data-year="2023 - 至今" role="listitem">
+          <h3>自由职业 · 数字产品工作室</h3>
+          <p>
+            独立服务多家初创团队，从品牌定位、信息架构到前端实现提供一站式支持。
+            通过快速原型和用户验证，在三个月内帮助客户完成从 0 到 1 的产品上线。
+          </p>
+        </article>
+        <article class="timeline-item" data-year="2020 - 2023" role="listitem">
+          <h3>某互联网公司 · 高级产品设计师</h3>
+          <p>
+            负责企业 SaaS 平台的整体设计体系建设，与工程团队紧密合作，推动设计系统组件化。
+            期间主导的设计方案帮助核心功能转化率提升 32%。
+          </p>
+        </article>
+        <article class="timeline-item" data-year="2017 - 2020" role="listitem">
+          <h3>某创新实验室 · 前端工程师</h3>
+          <p>
+            参与多个交互式数据可视化项目，兼顾性能优化与视觉呈现。通过自动化工具链将部署时间
+            缩短至原来的 40%，保障多团队协同效率。
+          </p>
+        </article>
+      </div>
+    </section>
+
+    <section id="projects" aria-labelledby="projects-title">
+      <h2 class="section-title" id="projects-title">精选项目</h2>
+      <div class="timeline" role="list">
+        <article class="timeline-item" data-year="2024" role="listitem">
+          <h3>FocusFlow · AI 驱动的专注助理</h3>
+          <p>
+            一款结合任务管理与情绪反馈的智能助手。负责产品体验设计与前端实现，打造沉浸式的
+            番茄工作流，帮助超 5,000 名用户找回创造力。
+          </p>
+          <div class="chips">
+            <span class="chip">Vue 3</span>
+            <span class="chip">Tailwind CSS</span>
+            <span class="chip">OpenAI API</span>
+          </div>
+        </article>
+        <article class="timeline-item" data-year="2023" role="listitem">
+          <h3>Palette Studio · 品牌视觉自动化平台</h3>
+          <p>
+            通过可视化编辑器和模板引擎，实现品牌资产的自动化生成。主导界面设计与关键交互，实现
+            设计与开发流程协同，日均处理 2,000+ 设计请求。
+          </p>
+          <div class="chips">
+            <span class="chip">React</span>
+            <span class="chip">TypeScript</span>
+            <span class="chip">Figma API</span>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section id="contact" aria-labelledby="contact-title">
+      <h2 class="section-title" id="contact-title">联系我</h2>
+      <div class="info-card">
+        <p>
+          如果你正在寻找一位能够整合产品策略、设计与前端工程的伙伴，欢迎随时联系我。一起聊聊你的想法吧！
+        </p>
+        <p><strong>邮箱：</strong> <a href="mailto:hello@chengyh.me">hello@chengyh.me</a></p>
+        <p><strong>微信：</strong> chengyh-create</p>
+        <p><strong>社交：</strong> <a href="https://www.linkedin.com" rel="noopener">LinkedIn</a> ·
+          <a href="https://dribbble.com" rel="noopener">Dribbble</a> ·
+          <a href="https://github.com/chengyh" rel="noopener">GitHub</a>
+        </p>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <p>© <span id="year"></span> Cheng YH. Crafted with curiosity &amp; caffeine.</p>
+  </footer>
+
+  <script>
+    const yearElement = document.getElementById("year");
+    const currentYear = new Date().getFullYear();
+    yearElement.textContent = currentYear;
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a polished single-page personal website layout in `index.html`
- include responsive sections for profile, experience, projects, and contact information

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c9050069a08333a75ae8b382947381